### PR TITLE
Community-tools update

### DIFF
--- a/src/components/ui/blocks/MainSection.astro
+++ b/src/components/ui/blocks/MainSection.astro
@@ -27,7 +27,7 @@ interface Props {
     </h1>
     <!-- Section subtitle -->
     <p set:html={description}
-      class="mb-8 max-w-prose text-pretty font-light text-neutral-600 dark:text-neutral-400 sm:text-xl"
+      class="mb-8 max-w-prose text-pretty font-light text-neutral-600 dark:text-neutral-400 sm:text-xl [&_a]:underline [&_a]:decoration-primary-600 [&_a:hover]:decoration-primary-700 dark:[&_a]:decoration-primary-500 dark:[&_a:hover]:decoration-primary-400"
     >
     </p>
     <!-- Conditional rendering of PrimaryCTA component if 'btnExists' property is truthy -->

--- a/src/pages/community-tools.astro
+++ b/src/pages/community-tools.astro
@@ -1,5 +1,5 @@
 ---
-import MainLayout from "@/layouts/MainLayout.astro";
+import MainLayout from "../layouts/MainLayout.astro";
 import { SITE } from "@data/constants";
 import MainSection from "../components/ui/blocks/MainSection.astro";
 import CommunityToolsTable from "../components/ui/tables/CommunityToolsTable.astro";
@@ -31,4 +31,18 @@ const pageTitle: string = `Community Tools — ${SITE.title}`;
     description=" We are lucky to have a community that doesn't only build with Spryker, but also contributes back to the ecosystem! Below you'll find a list of - non-official - resources that have been created by our community that can help you work better and faster with our products. In no particular order:"
   />
   <CommunityToolsTable tools={communityTools} />
+  <MainSection
+    title="Want more?"
+    description="The extensions & tools above are - more or less - being used in production. We also have a lot of MVP/POC projects (often coming from the Hackathons we organize) that migth not be production ready (yet), but could provide a perfect starting point for your next project."
+    btnExists={true}
+    btnTitle="Check out community repositories"
+    btnURL="https://github.com/orgs/spryker-community/repositories"
+  />
+  <MainSection
+    title="Share Your Project"
+    description="Have you built something amazing that could benefit the community? We'd love to help you share it! To get started, reach out to Florian on our forum to request a new repository in the Spryker Community organization. Once approved, you can contribute your code following our <a href='https://github.com/spryker-community/docs/blob/main/CONTRIBUTE.md' class='text-primary-600 hover:text-primary-700 dark:text-primary-500 dark:hover:text-primary-400'>contribution guidelines</a>. Your project could be the next valuable addition to our growing ecosystem!"
+    btnExists={true}
+    btnTitle="Request Repository on Forum"
+    btnURL="https://forum.commercequest.space/categories/spryker-community-projects"
+  />
 </MainLayout>

--- a/src/pages/community-tools.astro
+++ b/src/pages/community-tools.astro
@@ -1,8 +1,8 @@
 ---
-import MainLayout from "../layouts/MainLayout.astro";
+import MainLayout from "@/layouts/MainLayout.astro";
 import { SITE } from "@data/constants";
-import MainSection from "../components/ui/blocks/MainSection.astro";
-import CommunityToolsTable from "../components/ui/tables/CommunityToolsTable.astro";
+import MainSection from "@/components/ui/blocks/MainSection.astro";
+import CommunityToolsTable from "@/components/ui/tables/CommunityToolsTable.astro";
 import communityTools from "@data/communityTools.json";
 
 const pageTitle: string = `Community Tools — ${SITE.title}`;


### PR DESCRIPTION
Added 2 sections at the bottom of the community tools page:
- promoting hackathon projects
- showing people how to contribute

Also noticed that in blocks like these, links were indistinguishable from the rest of the text, so I updated the MainSection UI block as well to underline links.